### PR TITLE
DCMAW-8183 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:f25b0e9d3d116e267d4ff69a3a99c0f4cf6ae94eadd87f1bf7bd68ea3ff0bef7 as final
+FROM node:20-alpine@sha256:f25b0e9d3d116e267d4ff69a3a99c0f4cf6ae94eadd87f1bf7bd68ea3ff0bef7
 
 WORKDIR /app
 COPY src/ src/


### PR DESCRIPTION


### What changed

A Dockerfile has been added to begin the Docker-ECR-ECS deployment pattern of the FrontEnd Stub app.

This Dockerfile can be built to create a Docker image
This Dockerfile can be run to generate the UI locally

<img width="1428" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/112948043/567d1807-5b9d-4a40-b698-f4840bae3341">

<img width="720" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/112948043/de401f17-5498-4bec-826c-c3b5741a43f6">

<img width="944" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/112948043/0afc4c6e-31f1-46ad-bbe4-77fd13eb97fa">


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-8183](https://govukverify.atlassian.net/browse/DCMAW-8183)



[DCMAW-8183]: https://govukverify.atlassian.net/browse/DCMAW-8183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ