### PR TITLE
DCMAW 8185 GitHub Actions for deploying to build

### DIFF
--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -63,9 +63,6 @@ jobs:
           cd deploy ${GITHUB_WORKSPACE} || exit 1
           sam build --cached
 
-      - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t ./template.yaml
-
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@1bf704ccba8eaebea0bd43318321d806b29f9fe4 # pin@v3.5
         with:


### PR DESCRIPTION

### What changed

A Push-to-main workflow has been created that build the Dockerfile and then pushes it to ECR. The workflow will also utilise secure pipelines and push the template yaml build artefact to S3 and deploy the resources (not yet written) to the build environment.

### Why did it change

This is part of the Stub container deployment 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-8185](https://govukverify.atlassian.net/browse/DCMAW-8185)


[DCMAW-8185]: https://govukverify.atlassian.net/browse/DCMAW-8185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ