### PR TITLE
fix(DCMAW-8410) give walletFe role permisison to sign using kms key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -514,6 +514,12 @@ Resources:
               - "kms:*"
             Resource:
               - "*"
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt WalletFEECSTaskRole.Arn
+            Action: kms:Sign
+            Resource:
+              - "*"
       KeySpec: RSA_4096
       KeyUsage: SIGN_VERIFY
       MultiRegion: false


### PR DESCRIPTION
## Proposed changes
Give the document-builder task role permission to sign using the kms key

### Why did it change
Without this permission the container is unable to sign a payload, therefore the sts-stub api was returning a 500 error. 

### Issue tracking
https://govukverify.atlassian.net/browse/DCMAW-8410

Proof of working in dev environment:
![Screenshot 2024-04-12 at 07 58 38](https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/24165331/645e0cb1-c416-465d-817b-8db673e22b18)
