### PR TITLE
DCMAW-8706 WAF association

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -597,3 +597,11 @@ Resources:
           Value: Mobile Wallet Team
         - Key: Environment
           Value: !Ref "Environment"
+
+# WAF ASSOCIATION
+
+  DocBuilderWebAclAssociation:
+      Type: AWS::WAFv2::WebACLAssociation
+      Properties:
+        ResourceArn: !Ref WalletFELoadBalancer
+        WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/WafArn}}"


### PR DESCRIPTION
### Why did it change

Associated the document builder Loadbalancer with WAF

- [DCMAW-8706](https://govukverify.atlassian.net/browse/DCMAW-8706)

<img width="1103" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/112948043/18bf2a1c-2280-42c4-9188-f8a0038bde3c">


[DCMAW-8706]: https://govukverify.atlassian.net/browse/DCMAW-8706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ