### PR TITLE
fix(DCMAW): add kms:GetPublicKey permission to STS stub signing key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -533,7 +533,9 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: !GetAtt WalletFEECSTaskRole.Arn
-            Action: kms:Sign
+            Action:
+              - 'kms:Sign'
+              - 'kms:GetPublicKey'
             Resource:
               - "*"
       KeySpec: RSA_4096


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed
Give app permissions to retrieve the STS stub signing public key

Changes deployed to `dev`: 
![Screenshot 2024-04-22 at 12 05 21](https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/85736783/fdf1b184-43ed-4a43-a577-414b87c68beb)

### Why did it change
App must be able to retrieve public key

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)
- No ticket raised

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->