### PR TITLE
DCMAW 8708

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -646,11 +646,11 @@ Resources:
             Period: 60
             Stat: Minimum
 
-  BE4XXErrorAlarm:
+  BE5XXErrorAlarm:
     Condition: IsBuild
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-BE4XXErrorAlarm"
+      AlarmName: !Sub "${AWS::StackName}-BE5XXErrorAlarm"
       AlarmDescription: Trigger the alarm if errorThreshold exceeds 50% with a minimum of 5 invocations in the last 30 minutes
       ActionsEnabled: false
       # OKActions:
@@ -685,7 +685,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: AWS/ApiGateway
-              MetricName: 4xx
+              MetricName: 5xx
               Dimensions:
                 - Name: ApiId
                   Value: !Ref WalletFEApiGwHttpEndpoint


### PR DESCRIPTION
### What changed

Added low container alarm to ensure that 1 container was always up for do builder
Added 4xx alarm to monitor errors in api traffic

Made access logs bucket dynamic to improve developer deployment in dev

These alarms are conditional for build env 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-8708](https://govukverify.atlassian.net/browse/DCMAW-8708)

<img width="825" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/112948043/94d09c68-9758-4f39-b426-f4a72f2bf3c4">

<img width="819" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/112948043/d6c2542d-4088-49f8-987e-00bcf72c4340">



[DCMAW-8708]: https://govukverify.atlassian.net/browse/DCMAW-8708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ