### PR TITLE
fix(DCMAW): add missing DB action to WalletFEECSTaskRole

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -499,7 +499,9 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: 'dynamodb:PutItem'
+                Action:
+                  - 'dynamodb:PutItem'
+                  - 'dynamodb:GetItem'
                 Resource: !GetAtt DocumentDatabase.Arn
               - Effect: Allow
                 Action: 


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed

- Add 'dynamodb:GetItem' action to WalletFEECSTaskRole

### Why did it change

- WalletFEECSTaskRole must be able to fetch items from the DynamoDB table

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- Relates to [DCMAW-8607](https://govukverify.atlassian.net/browse/DCMAW-8607)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-8607]: https://govukverify.atlassian.net/browse/DCMAW-8607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ