### PR TITLE
fix(DCMAW-8925): correct key type in SAM template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -540,7 +540,7 @@ Resources:
               - 'kms:GetPublicKey'
             Resource:
               - "*"
-      KeySpec: RSA_4096
+      KeySpec: ECC_NIST_P256
       KeyUsage: SIGN_VERIFY
       MultiRegion: false
 


### PR DESCRIPTION
## Proposed changes

This PR relates to https://github.com/govuk-one-login/mobile-wallet-document-builder/pull/43

### What changed

- Update signing key type to make it compatible with signing algorithm ECDSA_SHA_256

### Why did it change

- Key type must be compatible with signing algorithm

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-8925](https://govukverify.atlassian.net/browse/DCMAW-8925)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [x] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-8925]: https://govukverify.atlassian.net/browse/DCMAW-8925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ