### PR TITLE
feat(DCMAW): make default dates have two digits

### DIFF
--- a/src/dbsDocumentBuilder/views/dbs-document-details-form.njk
+++ b/src/dbsDocumentBuilder/views/dbs-document-details-form.njk
@@ -32,7 +32,7 @@
                     {
                         "classes": "govuk-input--width-2",
                         "name": "month",
-                        "value": "1"
+                        "value": "01"
                     },
                     {
                         "classes": "govuk-input--width-3",
@@ -78,12 +78,12 @@
                     {
                         "classes": "govuk-input--width-2",
                         "name": "day",
-                        "value": "6"
+                        "value": "06"
                     },
                     {
                         "classes": "govuk-input--width-2",
                         "name": "month",
-                        "value": "3"
+                        "value": "03"
                     },
                     {
                         "classes": "govuk-input--width-3",


### PR DESCRIPTION
## Proposed changes


### What changed
- Make pre-filled dates in the DBS form page have double digits for day and month

https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/85736783/c90a8cbb-be3a-4ea6-8a4f-e193a5e3abee


### Why did it change
- To conform with the Wallet app

### Issue tracking
- No ticket raised for this change

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->