### PR TITLE
make placeholder walletSubjectId a valid value

### DIFF
--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -65,3 +65,7 @@ export function getOIDCDiscoveryEndpoint(): string {
 export function getCookieTtlInSecs(): string {
   return getEnvVarValue("COOKIE_TTL_IN_SECS");
 }
+
+export function getPlaceholderWalletSubjectId(): string {
+  return "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i";
+}

--- a/src/credentialOfferViewer/controller.ts
+++ b/src/credentialOfferViewer/controller.ts
@@ -4,6 +4,7 @@ import { getCredentialOffer } from "./services/credentialOfferService";
 import { getCustomCredentialOfferUri } from "./helpers/customCredentialOfferUri";
 import { logger } from "../middleware/logger";
 import { isAuthenticated } from "../utils/isAuthenticated";
+import { getPlaceholderWalletSubjectId } from "../config/appConfig";
 
 export async function credentialOfferViewerController(
   req: Request,
@@ -14,7 +15,7 @@ export async function credentialOfferViewerController(
     const selectedApp = req.cookies.app as string;
     const credentialType = req.query.type as string;
     const errorScenario = req.query.error as string;
-    const walletSubjectId = "walletSubjectIdPlaceholder";
+    const walletSubjectId = getPlaceholderWalletSubjectId();
 
     const response = await getCredentialOffer(
       walletSubjectId,

--- a/src/dbsDocumentBuilder/controller.ts
+++ b/src/dbsDocumentBuilder/controller.ts
@@ -5,6 +5,7 @@ import { saveDocument } from "../services/databaseService";
 import { CredentialType } from "../types/CredentialType";
 import { logger } from "../middleware/logger";
 import { isAuthenticated } from "../utils/isAuthenticated";
+import { getPlaceholderWalletSubjectId } from "../config/appConfig";
 
 const CREDENTIAL_TYPE = CredentialType.basicCheckCredential;
 
@@ -31,7 +32,7 @@ export async function dbsDocumentBuilderPostController(
     logger.info(`Processing DBS document with documentId ${documentId}`);
     const selectedError = req.body["throwError"];
     const document = DbsDocument.fromRequestBody(req.body, CREDENTIAL_TYPE);
-    const walletSubjectId = "walletSubjectIdPlaceholder";
+    const walletSubjectId = getPlaceholderWalletSubjectId();
     await saveDocument(document, documentId, walletSubjectId);
 
     res.redirect(

--- a/src/ninoDocumentBuilder/controller.ts
+++ b/src/ninoDocumentBuilder/controller.ts
@@ -5,6 +5,7 @@ import { saveDocument } from "../services/databaseService";
 import { CredentialType } from "../types/CredentialType";
 import { logger } from "../middleware/logger";
 import { isAuthenticated } from "../utils/isAuthenticated";
+import { getPlaceholderWalletSubjectId } from "../config/appConfig";
 
 const CREDENTIAL_TYPE = CredentialType.socialSecurityCredential;
 
@@ -31,7 +32,7 @@ export async function ninoDocumentBuilderPostController(
     logger.info(`Processing NINO document with documentId ${documentId}`);
     const selectedError = req.body["throwError"];
     const document = NinoDocument.fromRequestBody(req.body, CREDENTIAL_TYPE);
-    const walletSubjectId = "walletSubjectIdPlaceholder";
+    const walletSubjectId = getPlaceholderWalletSubjectId();
     await saveDocument(document, documentId, walletSubjectId);
 
     res.redirect(

--- a/src/stsStubAccessToken/controller.ts
+++ b/src/stsStubAccessToken/controller.ts
@@ -6,12 +6,11 @@ import {
 } from "./token/validateTokenRequest";
 import {
   getAccessTokenTtlInSecs,
+  getPlaceholderWalletSubjectId,
   getStsSigningKeyId,
 } from "../config/appConfig";
 import { logger } from "../middleware/logger";
 import { PREAUTHORIZED_CODE_ERRORS } from "./types/PreAuthorizedCodeErrors";
-
-const WALLET_SUBJECT_ID = "walletSubjectIdPlaceholder";
 
 export async function stsStubAccessTokenController(
   req: Request,
@@ -40,7 +39,7 @@ export async function stsStubAccessTokenController(
     logger.info(`Valid pre-authorized code received: ${preAuthorizedCode}`);
 
     const accessToken = await getJwtAccessToken(
-      WALLET_SUBJECT_ID,
+      getPlaceholderWalletSubjectId(),
       payload,
       getStsSigningKeyId()
     );

--- a/test/config/appConfig.test.ts
+++ b/test/config/appConfig.test.ts
@@ -12,6 +12,7 @@ import {
   getOIDCDiscoveryEndpoint,
   getCookieTtlInSecs,
   getClientSigningKeyId,
+  getPlaceholderWalletSubjectId,
 } from "../../src/config/appConfig";
 
 describe("appConfig.ts", () => {
@@ -148,5 +149,11 @@ describe("appConfig.ts", () => {
   it("should return COOKIE_TTL_IN_SECS environment variable value if set", () => {
     process.env.COOKIE_TTL_IN_SECS = "200";
     expect(getCookieTtlInSecs()).toEqual("200");
+  });
+
+  it("should return valid wallet subject id", () => {
+    expect(getPlaceholderWalletSubjectId()).toEqual(
+      "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i"
+    );
   });
 });

--- a/test/credentialOfferViewer/controller.test.ts
+++ b/test/credentialOfferViewer/controller.test.ts
@@ -4,6 +4,7 @@ import * as customCredentialOfferUri from "../../src/credentialOfferViewer/helpe
 
 import QRCode from "qrcode";
 import { getMockReq, getMockRes } from "@jest-mock/express";
+import { PLACEHOLDER_WALLET_SUBJECT_ID } from "../testConfig";
 
 jest.mock(
   "../../src/credentialOfferViewer/services/credentialOfferService",
@@ -61,7 +62,7 @@ describe("controller.ts", () => {
     await credentialOfferViewerController(req, res);
 
     expect(getCredentialOffer).toHaveBeenCalledWith(
-      "walletSubjectIdPlaceholder",
+      PLACEHOLDER_WALLET_SUBJECT_ID,
       "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
       "BasicCheckCredential"
     );

--- a/test/credentialOfferViewer/services/credentialOfferService.test.ts
+++ b/test/credentialOfferViewer/services/credentialOfferService.test.ts
@@ -1,6 +1,7 @@
 process.env.MOCK_CRI_URL = "http://localhost:1234";
 import { getCredentialOffer } from "../../../src/credentialOfferViewer/services/credentialOfferService";
 import axios, { AxiosResponse } from "axios";
+import { PLACEHOLDER_WALLET_SUBJECT_ID } from "../../testConfig";
 
 jest.mock("axios");
 
@@ -12,7 +13,7 @@ describe("credentialOfferService.ts", () => {
   const mockedAxios = axios as jest.Mocked<typeof axios>;
 
   it("should fetch and return the credential offer URI", async () => {
-    const walletSubjectId = "walletSubjectIdPlaceholder";
+    const walletSubjectId = PLACEHOLDER_WALLET_SUBJECT_ID;
     const documentId = "2e0fac05-4b38-480f-9cbd-b046eabe1e46";
     const credentialType = "BasicCheckCredential";
     const criResponseMocked = {
@@ -36,7 +37,7 @@ describe("credentialOfferService.ts", () => {
         params: {
           credentialType: "BasicCheckCredential",
           documentId: "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-          walletSubjectId: "walletSubjectIdPlaceholder",
+          walletSubjectId: PLACEHOLDER_WALLET_SUBJECT_ID,
         },
       }
     );
@@ -47,7 +48,7 @@ describe("credentialOfferService.ts", () => {
   });
 
   it("should catch an axios error and throw it", async () => {
-    const walletSubjectId = "walletSubjectIdPlaceholder";
+    const walletSubjectId = PLACEHOLDER_WALLET_SUBJECT_ID;
     const documentId = "2e0fac05-4b38-480f-9cbd-b046eabe1e46";
     const credentialType = "BasicCheckCredential";
     mockedAxios.isAxiosError.mockReturnValue(true);
@@ -59,7 +60,7 @@ describe("credentialOfferService.ts", () => {
   });
 
   it("should catch a non-axios error and throw it", async () => {
-    const walletSubjectId = "walletSubjectIdPlaceholder";
+    const walletSubjectId = PLACEHOLDER_WALLET_SUBJECT_ID;
     const documentId = "2e0fac05-4b38-480f-9cbd-b046eabe1e46";
     const credentialType = "BasicCheckCredential";
     mockedAxios.isAxiosError.mockReturnValue(false);

--- a/test/dbsDocumentBuilder/controller.test.ts
+++ b/test/dbsDocumentBuilder/controller.test.ts
@@ -5,6 +5,7 @@ import {
 import { DbsDocument } from "../../src/dbsDocumentBuilder/models/dbsDocument";
 import * as databaseService from "../../src/services/databaseService";
 import { getMockReq, getMockRes } from "@jest-mock/express";
+import { PLACEHOLDER_WALLET_SUBJECT_ID } from "../testConfig";
 
 jest.mock("node:crypto", () => ({
   randomUUID: jest.fn().mockReturnValue("2e0fac05-4b38-480f-9cbd-b046eabe1e46"),
@@ -120,7 +121,7 @@ describe("controller.ts", () => {
     expect(saveDocument).toHaveBeenCalledWith(
       dbsDocument,
       "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-      "walletSubjectIdPlaceholder"
+      PLACEHOLDER_WALLET_SUBJECT_ID
     );
   });
 

--- a/test/ninoDocumentBuilder/controller.test.ts
+++ b/test/ninoDocumentBuilder/controller.test.ts
@@ -5,6 +5,7 @@ import {
   ninoDocumentBuilderGetController,
   ninoDocumentBuilderPostController,
 } from "../../src/ninoDocumentBuilder/controller";
+import { PLACEHOLDER_WALLET_SUBJECT_ID } from "../testConfig";
 
 jest.mock("node:crypto", () => ({
   randomUUID: jest.fn().mockReturnValue("2e0fac05-4b38-480f-9cbd-b046eabe1e46"),
@@ -86,7 +87,7 @@ describe("controller.ts", () => {
     expect(saveDocument).toHaveBeenCalledWith(
       ninoDocument,
       "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-      "walletSubjectIdPlaceholder"
+      PLACEHOLDER_WALLET_SUBJECT_ID
     );
   });
 

--- a/test/services/databaseService.test.ts
+++ b/test/services/databaseService.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { saveDocument, getDocument } from "../../src/services/databaseService";
 import "aws-sdk-client-mock-jest";
+import { PLACEHOLDER_WALLET_SUBJECT_ID } from "../testConfig";
 
 describe("databaseService.ts", () => {
   it("should save a document to the database table", async () => {
@@ -30,7 +31,7 @@ describe("databaseService.ts", () => {
       TableName: "testTable",
       Item: {
         documentId: "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-        walletSubjectId: "walletSubjectIdPlaceholder",
+        walletSubjectId: PLACEHOLDER_WALLET_SUBJECT_ID,
         vc: JSON.stringify(document),
       },
     };
@@ -45,7 +46,7 @@ describe("databaseService.ts", () => {
       saveDocument(
         document,
         "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-        "walletSubjectIdPlaceholder"
+        PLACEHOLDER_WALLET_SUBJECT_ID
       )
     ).resolves.not.toThrow();
     expect(dynamoDbMock).toHaveReceivedCommandWith(PutCommand, putItemCommand);
@@ -71,7 +72,7 @@ describe("databaseService.ts", () => {
       TableName: "testTable",
       Item: {
         documentId: "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-        walletSubjectId: "walletSubjectIdPlaceholder",
+        walletSubjectId: PLACEHOLDER_WALLET_SUBJECT_ID,
         vc: JSON.stringify(document),
       },
     };
@@ -82,7 +83,7 @@ describe("databaseService.ts", () => {
       saveDocument(
         document,
         "2e0fac05-4b38-480f-9cbd-b046eabe1e46",
-        "walletSubjectIdPlaceholder"
+        PLACEHOLDER_WALLET_SUBJECT_ID
       )
     ).rejects.toThrow("SOME_DATABASE_ERROR");
     expect(dynamoDbMock).toHaveReceivedCommandWith(PutCommand, putItemCommand);

--- a/test/testConfig.ts
+++ b/test/testConfig.ts
@@ -1,0 +1,2 @@
+export const PLACEHOLDER_WALLET_SUBJECT_ID: string =
+  "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i";


### PR DESCRIPTION
# Make the placeholder walletSubjectId a valid value and configured in one place

### What changed
Make the placeholder walletSubjectId a valid value so it will be accepted by the backend validation. 
Configure this value in one place for the application code and one place for the test code.

### Why did it change
So the backend can validate input parameters - thus preventing injection attacks.

### Testing 
Deployed this branch and the corresponding CRI change to Dev and tested that the changes are compatible.
![Screenshot 2024-07-03 at 16 54 25](https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/24165331/bc263bc6-39db-4a5a-8d54-5237eefbf8f9)
