### PR TITLE
feat(DCMAW-9581): point dev to build auth stub

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -47,7 +47,7 @@ Mappings:
       FEURL: "stub-credential-issuer.mobile.dev.account.gov.uk"
       FrontImageRepository: arn:aws:ecr:eu-west-2:671524980203:repository/wallet-doc-builder-ecr-containerrepository-lhfhbk5ayzry
       DidController: "did:web:wallet-api.mobile.dev.account.gov.uk"
-      OidcIssuerEndpoint: "https://oidc.integration.account.gov.uk"
+      OidcIssuerEndpoint: "https://auth-stub.mobile.build.account.gov.uk"
     build:
       BEURL: "example-credential-issuer.mobile.build.account.gov.uk"
       FEURL: "stub-credential-issuer.mobile.build.account.gov.uk"


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed

- Point Example CRI / Document Builder in the dev environment to the auth stub in the build environment

https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/85736783/bc24f18b-f70f-4a4d-9ca3-98e8121650ee


### Why did it change

- Example CRI / Document Builder must point to the auth stub in the dev environment and to One Login in the build environment

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-9581](https://govukverify.atlassian.net/browse/DCMAW-9581)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [x] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-9581]: https://govukverify.atlassian.net/browse/DCMAW-9581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ