### PR TITLE
fix(DCMAW): stop fetching user info when app is not a staging app

### DIFF
--- a/src/credentialOfferViewer/controller.ts
+++ b/src/credentialOfferViewer/controller.ts
@@ -16,12 +16,18 @@ export async function credentialOfferViewerController(
     const credentialType = req.query.type as string;
     const errorScenario = req.query.error as string;
 
-    const userInfo: UserInfo = await req.oidc.userinfo(
-      req.cookies.access_token,
-      { method: "GET", via: "header" }
-    );
+    let walletSubjectId;
+    if (selectedApp.includes("staging")) {
+      const userInfo: UserInfo = await req.oidc.userinfo(
+        req.cookies.access_token,
+        { method: "GET", via: "header" }
+      );
+      walletSubjectId = userInfo.wallet_subject_id;
+    } else {
+      walletSubjectId =
+        "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i";
+    }
 
-    const walletSubjectId = userInfo.wallet_subject_id;
     const response = await getCredentialOffer(
       walletSubjectId,
       documentId,


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed

- Fetch user info (wallet_subject_id) from auth only when the selected app is one of the staging apps

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->