### PR TITLE
DCMAW-10576: use port 8001 instead of 8888

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-PORT=8888
-SELF=http://localhost:8888
+PORT=8001
+SELF=http://localhost:8001
 DOCUMENTS_TABLE_NAME=documents
 ENVIRONMENT=local
 CREDENTIAL_ISSUER_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -99,25 +99,25 @@ npm run dev
 
 To start and test the credential offer endpoint, go to:
 
-[http://localhost:8888/select-app](http://localhost:8888/select-app)
+[http://localhost:8001/select-app](http://localhost:8001/select-app)
 
 To get a document's details, hit the following endpoint:
 
-[http://localhost:8888/document/:documentId](http://localhost:8888/document/:documentId)
+[http://localhost:8001/document/:documentId](http://localhost:8001/document/:documentId)
 
 To swap a pre-authorized code for an access token (STS Stub):
 ```
-curl -d "grant_type=urn:ietf:params:oauth:grant-type:pre-authorized_code&pre-authorized_code=eyJraWQiOiJmZjI3NWI5Mi0wZGVmLTRkZmMtYjBmNi04N2M5NmIyNmM2YzciLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ1cm46ZmRjOmdvdjp1azp3YWxsZXQiLCJjbGllbnRJZCI6IkVYQU1QTEVfQ1JJIiwiaXNzIjoidXJuOmZkYzpnb3Y6dWs6ZXhhbXBsZS1jcmVkZW50aWFsLWlzc3VlciIsImNyZWRlbnRpYWxfaWRlbnRpZmllcnMiOlsiYmYyODVjOTctMzFkNS00NGEwLWFkZGQtNDNmM2I0YmIzYmMwIl0sImV4cCI6MTcxMjMwNDMwOCwiaWF0IjoxNzEyMzA0MDA4fQ.2-qE4IKUJpUPo04O4m34W13o8f8V6zNuuJ0RBoSyPcBTZFtuJVTHM_4lhiGrOH9vysS8LxTYSSeyv7FugH4RJw" -X POST http://localhost:8888/token | jq
+curl -d "grant_type=urn:ietf:params:oauth:grant-type:pre-authorized_code&pre-authorized_code=eyJraWQiOiJmZjI3NWI5Mi0wZGVmLTRkZmMtYjBmNi04N2M5NmIyNmM2YzciLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ1cm46ZmRjOmdvdjp1azp3YWxsZXQiLCJjbGllbnRJZCI6IkVYQU1QTEVfQ1JJIiwiaXNzIjoidXJuOmZkYzpnb3Y6dWs6ZXhhbXBsZS1jcmVkZW50aWFsLWlzc3VlciIsImNyZWRlbnRpYWxfaWRlbnRpZmllcnMiOlsiYmYyODVjOTctMzFkNS00NGEwLWFkZGQtNDNmM2I0YmIzYmMwIl0sImV4cCI6MTcxMjMwNDMwOCwiaWF0IjoxNzEyMzA0MDA4fQ.2-qE4IKUJpUPo04O4m34W13o8f8V6zNuuJ0RBoSyPcBTZFtuJVTHM_4lhiGrOH9vysS8LxTYSSeyv7FugH4RJw" -X POST http://localhost:8001/token | jq
 ```
 
 To get a proof JWT for a given nonce and audience:
 ```
-curl -X GET http://localhost:8888/proof-jwt/?nonce=45ec1dd6-75f1-499a-8ec1-98c7d7086b91&audience=http://localhost:8080 | jq
+curl -X GET http://localhost:8001/proof-jwt/?nonce=45ec1dd6-75f1-499a-8ec1-98c7d7086b91&audience=http://localhost:8080 | jq
 ```
 
 To get the public key JWKs (STS Stub):
 ```
-curl -X GET http://localhost:8888/.well-known/jwks.json | jq
+curl -X GET http://localhost:8001/.well-known/jwks.json | jq
 ```
 
 #### Reading from the Database

--- a/test/logout/controller.test.ts
+++ b/test/logout/controller.test.ts
@@ -9,7 +9,7 @@ jest.mock("../../src/logout/utils/deleteCookies", () => ({
 
 const deleteCookies = utils.deleteCookies as jest.Mock;
 
-process.env.SELF = "http://localhost:8888";
+process.env.SELF = "http://localhost:8001";
 
 describe("controller.ts", () => {
   afterEach(() => {


### PR DESCRIPTION
Related PR: https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/85

## Proposed changes
### What changed
- Update Document Builder default port to be `8001` instead of `8888`

https://github.com/user-attachments/assets/ef8e4eb9-e6d9-40ef-9bd5-2ec56bb6003c

### Why did it change
The Document Builder will use port `8001` going forward as Docker Desktop started using port `8888` after a recent update and any containers binding to that port fail.

### Issue tracking
- [DCMAW-10576](https://govukverify.atlassian.net/browse/DCMAW-10576)

## Checklists
- [x] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates


[DCMAW-10576]: https://govukverify.atlassian.net/browse/DCMAW-10576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ