### PR TITLE
DCMAW-10912: credential offer screen button cannot be wider than page

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -6,7 +6,6 @@
 }
 
 .govuk-body {
-  inline-size: 700px;
   overflow-wrap: break-word;
   hyphens: manual;
 }


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed

Fix issue introduced by https://github.com/govuk-one-login/mobile-wallet-document-builder/pull/116 which caused the button on the credential offer page to become wider than the page itself on Safari on a physical device. 

**Bug:**
![image](https://github.com/user-attachments/assets/6689e74b-eb42-491f-96bf-b55026e09f62)

**Testing evidence following fix:**
<img width="1515" alt="Screenshot 2025-01-13 at 10 47 51" src="https://github.com/user-attachments/assets/289e7395-271b-4f95-962b-56927ddabc75" />

**Credential viewer page works as before:**

https://github.com/user-attachments/assets/a50f9b4b-15af-444f-bc20-2a8757529c09


### Why did it change

To fix the bug described above.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-10912](https://govukverify.atlassian.net/browse/DCMAW-10912)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-10912]: https://govukverify.atlassian.net/browse/DCMAW-10912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ