### PR TITLE
DCMAW-11069: update LocalStack Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   localstack:
     container_name: localstack_documentBuilder
@@ -8,5 +6,8 @@ services:
       - "4561:4566"
     environment:
       - SERVICES=dynamodb,kms
+      - AWS_ACCESS_KEY_ID=na
+      - AWS_SECRET_ACCESS_KEY=na
+      - AWS_DEFAULT_REGION=eu-west-2
     volumes:
       - ./localstack/provision.sh:/etc/localstack/init/ready.d/init-aws.sh


### PR DESCRIPTION
## Proposed changes
### What changed

- Add the following environment variables with the following values to the LocalStack Docker Compose file:
  - `AWS_ACCESS_KEY_ID=na`
  - `AWS_SECRET_ACCESS_KEY=na`
  - `AWS_DEFAULT_REGION=eu-west-2`
- Remove version from the LocalStack Docker Compose file as this parameter has been deprecated

### Why did it change
Default AWS credentials were removed from Init Hooks with the release of LocalStack 4.0 and must now be explicitly set.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-11069](https://govukverify.atlassian.net/browse/DCMAW-11069)

## Testing
**BEFORE:**
<img width="1467" alt="Screenshot 2025-01-16 at 11 01 32" src="https://github.com/user-attachments/assets/b6ad690e-22cb-44b6-8875-2066daf2064e" />


**AFTER:**
<img width="1467" alt="Screenshot 2025-01-16 at 11 02 51" src="https://github.com/user-attachments/assets/80aab38c-a71e-4a92-b1ed-e42be6940ea3" />
<img width="1467" alt="Screenshot 2025-01-16 at 11 03 29" src="https://github.com/user-attachments/assets/b59fc82c-5183-4580-aa18-12b29892280e" />

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/92

[DCMAW-11069]: https://govukverify.atlassian.net/browse/DCMAW-11069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ