### PR TITLE
BAU: group dependabot PRs and ignore node updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,29 +3,45 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
       time: "06:00"
-    target-branch: main
     labels:
       - dependencies
     commit-message:
       prefix: chore
-  - package-ecosystem: docker
+    groups:
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
       time: "06:00"
-    target-branch: main
     labels:
       - dependencies
     commit-message:
       prefix: chore
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
       time: "06:00"
-    target-branch: main
     labels:
       - dependencies
     commit-message:


### PR DESCRIPTION
## Proposed changes
### What changed
- Group dependabot PRs for npm dependency updates (patch and minor only)
- Ignore major updates of `node` version

### Why did it change
- So that there are less PRs to approve and merge

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
