### PR TITLE
BAU: Update configure_auth_stub bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ as [this one](https://github.com/govuk-one-login/mobile-platform-back/tree/main/
 
 To configure this stub to work with the Document Builder, run:
 ```
-./configure_auth_stub.sh
+./configure_auth_stub.sh <your_aws_profile>
 ```
 
 Both repositories must be in the same directory for the script to work.

--- a/configure_auth_stub.sh
+++ b/configure_auth_stub.sh
@@ -19,3 +19,6 @@ sed -i '' "s|^AUTH_STUB_BASE_URL=[^=]*$|AUTH_STUB_BASE_URL=${AUTH_STUB_BASE_URL}
 
 REDIRECT_URI="http://localhost:8001/return-from-auth"
 sed -i '' "s|^REDIRECT_URI=[^=]*$|REDIRECT_URI=${REDIRECT_URI}|" ../mobile-platform-back/auth-stub/.env
+
+AWS_PROFILE=$1
+sed -i '' "s|^AWS_PROFILE=[^=]*$|AWS_PROFILE=${AWS_PROFILE}|" ../mobile-platform-back/auth-stub/.env


### PR DESCRIPTION
## Proposed changes
### What changed
Enhance the `configure_auth_stub.sh` to also update the `AWS_PROFILE` environment variable value when making changes to the auth stub `.env` file. Going forward, users must provide their AWS profile as an argument when running the script.

### Why did it change
To make local testing easier.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
