### PR TITLE
DCMAW-12013: Update OidcIssuerEndpoint to point to Orch Staging env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -57,7 +57,7 @@ Mappings:
       CredentialIssuerUrl: "example-credential-issuer.mobile.staging.account.gov.uk"
       SelfUrl: "stub-credential-issuer.mobile.staging.account.gov.uk"
       FrontImageRepository: arn:aws:ecr:eu-west-2:497065468681:repository/wallet-doc-builder-ecr-containerrepository-zxs2g0lfhfsf
-      OidcIssuerEndpoint: "https://oidc.integration.account.gov.uk"
+      OidcIssuerEndpoint: "https://oidc.staging.account.gov.uk"
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   # PlatformConfiguration:
   #   dev:


### PR DESCRIPTION
## Proposed changes
### What changed

- Updated `OidcIssuerEndpoint` environment variable to point to Orchestration Staging environment (since STS is being updated to align with Staging environment [here](https://github.com/govuk-one-login/sts-back/pull/640)).
  - Note: The client ID secret stored in SSM Parameter Store (referenced in the template [here](https://github.com/govuk-one-login/mobile-wallet-document-builder/blob/552b920802243a6e8c97b1938592fa9ffe460c6f/deploy/template.yaml#L403)) will be updated manually once this change has been deployed.

### Why did it change
<!-- Describe the reason these changes were made -->

- Aligning STS and Wallet Staging environments with Orchestration's Staging environment. 

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-12013](https://govukverify.atlassian.net/browse/DCMAW-12013)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

Changes will be tested in Staging following deployment,

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-12013]: https://govukverify.atlassian.net/browse/DCMAW-12013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ