### PR TITLE
DCMAW-11597: display button before QR code

### DIFF
--- a/src/credentialOfferViewer/views/credential-offer.njk
+++ b/src/credentialOfferViewer/views/credential-offer.njk
@@ -5,7 +5,11 @@
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-3">Example GOV.UK Wallet Credential Issuer</h1>
     <h1 class="govuk-heading-m">Download your document to your GOV.UK Wallet</h1>
-    <p class="govuk-body">Scan this QR code on your mobile device:</p>
+    <p class="govuk-body">Click on the button below:</p>
+    <p class="govuk-body">
+        <a href={{ universalLink }} class="govuk-button" data-module="govuk-button">Open GOV.UK Wallet </a>
+    </p>
+    <p class="govuk-body">Or, scan this QR code on your mobile device:</p>
     <p class="govuk-body">
         <img id="qr-code"
              src="{{ qrCode }}"
@@ -13,11 +17,7 @@
              width="350"
              height="350">
     </p>
-    <p class="govuk-body">Or, click on the button below:</p>
-    <p class="govuk-body">
-        <a href={{ universalLink }} class="govuk-button" data-module="govuk-button">Open GOV.UK Wallet </a>
-    </p>
-    {{ govukWarningText({"text": "This QR code / deep link is valid for 15 minutes.", "iconFallbackText": "Warning"}) }}
+    {{ govukWarningText({"text": "This deep link / QR code is valid for 15 minutes.", "iconFallbackText": "Warning"}) }}
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
     <h1 class="govuk-heading-s" class="govuk-heading-m">Development Only</h1>
     <p class="govuk-body">


### PR DESCRIPTION
## Proposed changes
### What changed
- Display button to open wallet before the QR code in the credential offer page

### Why did it change
- To facilitate testing for mobile devs

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-11597](https://govukverify.atlassian.net/browse/DCMAW-11597)

## Testing

Deployed to the dev environment.

![image](https://github.com/user-attachments/assets/03815be4-d157-4cc3-987c-bbba9112b40e)


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-11597]: https://govukverify.atlassian.net/browse/DCMAW-11597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ