### PR TITLE
BAU: Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
   deploy_artifacts:
     name: "Deploy Image & Template to Dev"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   ci:
     name: Run tests, lint and validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out repository code

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -13,8 +13,7 @@ permissions:
 jobs:
   upload-s3-artifact-to-build:
     name: Validate & upload S3 artifact to build
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v3
         with:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-code-quality-and-security-analysis:
     name: Run code quality and security analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out repository code


### PR DESCRIPTION
## Proposed changes
### What changed
- Change all GA workflows  to run on  `ubuntu-24.04` 
- Change all GA workflows to use `npm ci` instead of `npm install`

These changes appear to fix an issue we are seeing when running the pull request workflow where the`npm install` step hangs and never finishes. 

### Why did it change
-  `ubuntu-24.04` is the most recent stable Ubuntu runner that GitHub supports
- `npm ci` is faster and more reliable for CI environments

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
BEFORE
<img width="2233" alt="Screenshot 2025-04-11 at 09 29 02" src="https://github.com/user-attachments/assets/56aed2a0-0e39-4344-8447-c6a861c6a46c" />

AFTER
<img width="2233" alt="Screenshot 2025-04-11 at 09 28 06" src="https://github.com/user-attachments/assets/c629d88d-964d-4821-a836-7a1fae45db0c" />

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
