### PR TITLE
DCMAW-10207: Update S3 buckets to use common access log bucket

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -656,8 +656,10 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
       LoggingConfiguration:
-        DestinationBucketName: !Ref PhotosBucketAccessLogs
-        LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-photos-access-logs
+        DestinationBucketName: !ImportValue devplatform-s3-access-logs-bucket-S3AccessLogsBucketName
+        TargetObjectKeyFormat:
+          PartitionedPrefix:
+            PartitionDateSource: EventTime
       Tags:
         - Key: Product
           Value: GOV.UK Sign In
@@ -689,6 +691,8 @@ Resources:
 
   PhotosBucketAccessLogs:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${AWS::StackName}-${Environment}-photos-access-logs
       VersioningConfiguration:


### PR DESCRIPTION
## Proposed changes
### What changed
- Updated all S3 buckets to use common Dev Platform S3 access log bucket `devplatform-s3-access-logs-bucket-S3AccessLogsBucketName`
- Modified current S3 access log buckets to allow for deletion in follow-up PR.

### Why did it change

- Allows utilisation of common access logs bucket, and to allow for removal of previously used individual access logs buckets.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-10207](https://govukverify.atlassian.net/browse/DCMAW-10207)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/a29b0bdc-c255-4ae3-bae2-bd2e9f7cdbda" />
<img width="253" alt="image" src="https://github.com/user-attachments/assets/3f02fa92-d298-4b82-aa42-a90546cc7e62" />



## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-10207]: https://govukverify.atlassian.net/browse/DCMAW-10207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ