### PR TITLE
DCMAW-10207: Delete unused S3 access logs buckets

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -689,60 +689,6 @@ Resources:
               Bool:
                 "aws:SecureTransport": false
 
-  PhotosBucketAccessLogs:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      BucketName: !Sub ${AWS::StackName}-${Environment}-photos-access-logs
-      VersioningConfiguration:
-        Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: ObjectWriter
-
-  PhotosBucketAccessLogsPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref PhotosBucketAccessLogs
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: AllowSSLRequestsOnly
-            Effect: Deny
-            Principal:
-              AWS: "*"
-            Action: "*"
-            Resource: !Sub
-              - "arn:aws:s3:::${bucketName}/*"
-              - bucketName: !Ref PhotosBucketAccessLogs
-            Condition:
-              Bool:
-                "aws:SecureTransport": false
-          - Sid: AllowLogDelivery
-            Effect: Allow
-            Principal:
-              Service: logging.s3.amazonaws.com
-            Action:
-              - s3:PutObject
-            Resource: !Sub
-              - "arn:aws:s3:::${bucketName}/*"
-              - bucketName: !Ref PhotosBucketAccessLogs
-            Condition:
-              ArnLike:
-                aws:SourceArn: !GetAtt PhotosBucket.Arn
-              StringEquals:
-                aws:SourceAccount: !Ref AWS::AccountId
-
   # ALARMS
 
   DocBuilderLowContainerTaskCountAlarm:


### PR DESCRIPTION
## Proposed changes
### What changed
- Delete S3 access logs bucket which were made redundant by https://github.com/govuk-one-login/mobile-wallet-document-builder/pull/234.

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-10207](https://govukverify.atlassian.net/browse/DCMAW-10207)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-10207]: https://govukverify.atlassian.net/browse/DCMAW-10207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ