### PR TITLE
Update UI mDL default values

### DIFF
--- a/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
+++ b/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
@@ -354,7 +354,7 @@
                 "name": "issuing_country",
                 "classes": "govuk-!-width-one-third",
                 "spellcheck": false,
-                "value": "United Kingdom (UK)",
+                "value": "GB",
                 "disabled": true
             }) }}
             {{ govukInput({
@@ -366,7 +366,7 @@
                 "name": "document_number",
                 "classes": "govuk-!-width-one-third",
                 "spellcheck": false,
-                "value": "25057386"
+                "value": "HALL9655293DH5RO"
             }) }}
             {% call govukFieldset({
                 "legend": {


### PR DESCRIPTION
## Proposed changes
### What changed
- Update the default (and unchangeable) issuing country to be **"GB"**
- Update the default licence number to be **"HALL9655293DH5RO"**

### Why did it change
- To match the values provided by DVLA

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
Deployed to and tested in the `dev` environment.

![Screenshot 2025-05-14 at 10 33 48](https://github.com/user-attachments/assets/72be10c0-20e3-4196-b35a-bf120b005b2a)


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
