### PR TITLE
Enable mDL issuing country input field

### DIFF
--- a/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
+++ b/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
@@ -337,8 +337,7 @@
                 "name": "issuing_country",
                 "classes": "govuk-!-width-one-third",
                 "spellcheck": false,
-                "value": "GB",
-                "disabled": true
+                "value": "GB"
             }) }}
             {{ govukInput({
                 "label": {


### PR DESCRIPTION
## Proposed changes
### What changed
- Enable the UI field for inputting the driving licence issuing country (previously disabled)

### Why did it change
- To make development easier: when the input field is disabled, the field is not included in the request body, and has to be manually set in the backend

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
Tested locally.

https://github.com/user-attachments/assets/6349670b-c81b-4e0c-99a3-d926335ca06e

![Screenshot 2025-05-14 at 16 27 19](https://github.com/user-attachments/assets/97f9c71f-6960-4ab4-aed8-01aea736cde7)




## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
