### PR TITLE
DCMAW-13559 Update typ value in proofJWT header

### DIFF
--- a/src/proofJwt/proofJwt.ts
+++ b/src/proofJwt/proofJwt.ts
@@ -11,7 +11,7 @@ import format from "ecdsa-sig-formatter";
 import { createPublicKey, JsonWebKey } from "node:crypto";
 const bs58 = require("bs58");
 
-const ACCESS_TOKEN_SIGNING_ALGORITHM = "ES256";
+const PROOF_TOKEN_SIGNING_ALGORITHM = "ES256";
 const PROOF_TOKEN_JWT_TYPE = "openid4vci-proof+jwt";
 
 export async function getProofJwt(
@@ -25,7 +25,7 @@ export async function getProofJwt(
   const didKey = createDidKey(publicKeyJwk);
 
   const header = {
-    alg: ACCESS_TOKEN_SIGNING_ALGORITHM,
+    alg: PROOF_TOKEN_SIGNING_ALGORITHM,
     typ: PROOF_TOKEN_JWT_TYPE,
     kid: didKey,
   };


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
Update the value of the typ parameter to be "openid4vci-proof+jwt" 

### Why did it change
<!-- Describe the reason these changes were made -->
The [OID4VCI specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-8.2.1.1) requires that the proof of possession JWT includes a typ header parameter with the value "openid4vci-proof+jwt". 

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13559](https://govukverify.atlassian.net/browse/DCMAW-13559)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
<img width="608" alt="Screenshot 2025-06-17 at 16 19 23" src="https://github.com/user-attachments/assets/89dd1a81-f942-4ec6-98de-292125fd33b9" />

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13559]: https://govukverify.atlassian.net/browse/DCMAW-13559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ