### PR TITLE
BAU: Allow viewing credential only when not in staging

### DIFF
--- a/src/credentialOfferViewer/controller.ts
+++ b/src/credentialOfferViewer/controller.ts
@@ -5,7 +5,7 @@ import { customiseCredentialOfferUrl } from "./helpers/customCredentialOfferUrl"
 import { logger } from "../middleware/logger";
 import { isAuthenticated } from "../utils/isAuthenticated";
 import { UserInfo } from "./types/UserInfo";
-import { apps } from "../config/appConfig";
+import { apps, getEnvironment } from "../config/appConfig";
 
 export async function credentialOfferViewerController(
   req: Request,
@@ -42,6 +42,7 @@ export async function credentialOfferViewerController(
       authenticated: isAuthenticated(req),
       universalLink: customisedCredentialOfferUrl,
       qrCode,
+      environment: getEnvironment(),
     });
   } catch (error) {
     logger.error(

--- a/src/credentialOfferViewer/views/credential-offer.njk
+++ b/src/credentialOfferViewer/views/credential-offer.njk
@@ -18,15 +18,17 @@
              height="350">
     </p>
     {{ govukWarningText({"text": "This deep link / QR code is valid for 15 minutes.", "iconFallbackText": "Warning"}) }}
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-    <h1 class="govuk-heading-s" class="govuk-heading-m">Development Only</h1>
-    <p class="govuk-body">
-        <a href="/view-credential/?offer={{ universalLink }}"
-           class="govuk-link"
-           rel="noreferrer noopener"
-           target="_blank">View credential</a>
-    </p>
-    {{ govukInsetText({
-      text: "This link only works in development and build environments. Clicking on this link will display the credential on a new page. You will not be able to scan the QR code to load the credential in to the wallet after that. This link will also not work after the credential has been loaded in to the wallet."
-    }) }}
+    {% if environment != "staging" %}
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <h1 class="govuk-heading-s govuk-heading-m">Development Only</h1>
+        <p class="govuk-body">
+            <a href="/view-credential/?offer={{ universalLink }}"
+               class="govuk-link"
+               rel="noreferrer noopener"
+               target="_blank">View credential</a>
+        </p>
+        {{ govukInsetText({
+            "text": "Clicking on this link will display the credential on a new page. You will not be able to scan the QR code to load the credential in to the wallet after that. This link will also not work after the credential has been loaded in to the wallet."
+        }) }}
+    {% endif %}
 {% endblock %}

--- a/test/credentialOfferViewer/controller.test.ts
+++ b/test/credentialOfferViewer/controller.test.ts
@@ -3,6 +3,9 @@ import * as credentialOfferService from "../../src/credentialOfferViewer/service
 import * as customCredentialOfferUrl from "../../src/credentialOfferViewer/helpers/customCredentialOfferUrl";
 import { getMockReq, getMockRes } from "@jest-mock/express";
 
+const ENVIRONMENT = "test";
+process.env.ENVIRONMENT = ENVIRONMENT;
+
 export const WALLET_SUBJECT_ID =
   "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i";
 
@@ -80,6 +83,7 @@ describe("controller.ts", () => {
       qrCode: "data:image/png;base64,iVBORw0KGgoAAAANSU",
       universalLink:
         "https://mobile.build.account.gov.uk/test-wallet/add?credential_offer=https://mobile.dev.account.gov.uk/wallet-test/add?credential_offer=%7B%22credentials%22%3A%5B%22SocialSecurityCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22eyJraWQiOiI3OGZhMTMxZDY3N2MxYWMwZjE3MmM1M2I0N2FjMTY5YTk1YWQwZDkyYzM4YmQ3OTRhNzBkYTU5MDMyMDU4Mjc0IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjgwMDEiLCJjbGllbnRJZCI6IlRFU1RfQ0xJRU5UX0lEIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwiY3JlZGVudGlhbF9pZGVudGlmaWVycyI6WyI1ZjM5YTY4Zi02M2MzLTRkMGYtODdlNy0yNGYyNzRjZWJkYWYiXSwiZXhwIjoxNzM2NTA2NzkzLCJpYXQiOjE3MzY1MDY0OTN9.AHeaVwMBqlTOO1Qmgg38-OWiSTs-AmEtLJafz6Ks31CCqHiXJ_QujmK5jJGWpry8X84FSksPhhGoTIG61TbLuQ%22%7D%7D%2C%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D",
+      environment: ENVIRONMENT,
     });
   });
 


### PR DESCRIPTION
## Proposed changes
### What changed
- Display the **View credential** link in the credential offer page only when running in environments other than staging

### Why did it change
- This feature does not work in staging

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
Deployed to and tested in the development environment. It will only be possible to test in build and staging once this PR is merged.

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/b066efed-1846-4daa-ba0b-38e2e96dcc7e" />


## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
