### PR TITLE
chore: update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# This is the CODEOWNERS file. These owners will be the default owners for everything in the DI-IPV-DCA-iOS repository
+# This is the CODEOWNERS file. These owners will be the default owners for everything in the mobile-wallet-document-builder repository.
 # The following below will be requested for review when someone opens a pull request.
 
-* @govuk-one-login/mobile-wallet-team @govuk-one-login/mobile-leads @govuk-one-login/mobile-platform
+* @govuk-one-login/mobile-wallet-team @govuk-one-login/mobile-leads


### PR DESCRIPTION
## Proposed changes
### What changed
- Remove `@govuk-one-login/mobile-platform`.
- Correct repository name - should be `mobile-wallet-document-builder`.

### Why did it change
- Current content is incorrect.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
