### PR TITLE
fix: update vehicle category B-Automatic to have value of 'B auto'

### DIFF
--- a/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
+++ b/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
@@ -390,7 +390,7 @@
               { value: "A2", text: "A2 – Motorcycles with a power output up to 35 kW" },
               { value: "A", text: "A – Motorcycles over 35 kW or with a power-to-weight ratio exceeding 0.2 kW/kg" },
               { value: "B", text: "B - Cars (up to 3,500 kg MAM)" },
-              { value: "B", text: "B - Automatic transmission cars" },
+              { value: "B auto", text: "B - Automatic transmission cars" },
               { value: "BE", text: "BE - Car and trailer combinations (up to 3,500 kg MAM)" },
               { value: "B1", text: "B1 - Light vehicles and quadricycles" },
               { value: "C1", text: "C1 - Medium-sized vehicles (3,500–7,500 kg MAM)" },


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
- Set the value for Vehicle Category Code of `B Automatic transmission cars` to be `B auto`
### Why did it change
<!-- Describe the reason these changes were made -->
Currently when selecting the Vehicle Category Code of `B Automatic transmission cars`
the value in mDL appears as `B`but it should be `B auto`. This implementation fix this bug.


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15815](https://govukverify.atlassian.net/browse/DCMAW-15815)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
##### Tested locally
<img width="531" height="606" alt="Screenshot 2025-09-25 at 13 48 42" src="https://github.com/user-attachments/assets/b598497c-357b-4de2-9dad-5b89acdb80f9" />

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
