### PR TITLE
feat: add a `Continue` button at the top of the document page

### DIFF
--- a/src/dbsDocumentBuilder/views/dbs-document-details-form.njk
+++ b/src/dbsDocumentBuilder/views/dbs-document-details-form.njk
@@ -9,6 +9,7 @@
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-3">Example GOV.UK Wallet Credential Issuer</h1>
     <form action="/build-dbs-document" method="post">
+        {{ govukButton({"text": "Continue", "type": "Submit", "preventDoubleClick": true}) }}
         {% call govukFieldset({
             "legend": {
             "text": "Please enter the Clear Basic DBS Check document details:",

--- a/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
+++ b/src/mdlDocumentBuilder/views/mdl-document-details-form.njk
@@ -9,6 +9,7 @@
 {% block content %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Example GOV.UK Wallet Credential Issuer</h1>
   <form action="/build-mdl-document" method="post">
+    {{ govukButton({"text": "Continue", "type": "Submit", "preventDoubleClick": true}) }}
     {% call govukFieldset({
       legend: {
       text: pageTitle,

--- a/src/ninoDocumentBuilder/views/nino-document-details-form.njk
+++ b/src/ninoDocumentBuilder/views/nino-document-details-form.njk
@@ -8,6 +8,7 @@
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-3">Example GOV.UK Wallet Credential Issuer</h1>
     <form action="/build-nino-document" method="post">
+        {{ govukButton({"text": "Continue", "type": "Submit", "preventDoubleClick": true}) }}
         {% call govukFieldset({
             legend: {
             text: "Please enter the NINO document details:",

--- a/src/veteranCardDocumentBuilder/views/veteran-card-document-details-form.njk
+++ b/src/veteranCardDocumentBuilder/views/veteran-card-document-details-form.njk
@@ -11,6 +11,7 @@
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-3">Example GOV.UK Wallet Credential Issuer</h1>
     <form action="/build-veteran-card-document" method="post">
+        {{ govukButton({"text": "Continue", "type": "Submit", "preventDoubleClick": true}) }}
         {% call govukFieldset({
             legend: {
             text: "Please enter the Veteran Card document details:",


### PR DESCRIPTION
## Proposed changes
### What changed
- In the NINO/DBS/Vets/Driving Licence document pages, add an additional  `Continue` button at the top of the page.

### Why did it change
- So that users of the Document Builder can easily move to the next page without having to scroll to the bottom.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15979](https://govukverify.atlassian.net/browse/DCMAW-15979)

## Testing
Deployed to and tested in the development environment.

https://github.com/user-attachments/assets/ba29abab-d8c5-41f6-91a7-3bff68f68c74


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-15979]: https://govukverify.atlassian.net/browse/DCMAW-15979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ