### PR TITLE
feat: integrate with STS mock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ OIDC_CLIENT_ID=TEST_CLIENT_ID
 CLIENT_SIGNING_KEY_ID=14122ec4-cdd0-4154-8275-04363c15fbd9
 OIDC_ISSUER_DISCOVERY_ENDPOINT=http://localhost:8000
 WALLET_APPS=govuk-build,wallet-test-dev,wallet-test-build,wallet-test-verifier-integration
+ONE_LOGIN_AUTH_SERVER_URL=http://localhost:9090

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Start LocalStack to emulate AWS services (DynamoDB, S3, KMS) on port `4561`:
 npm run localstack:up
 ```
 
-Running locally also requires the example credential issuer for end-to-end journey functionality.
+Running locally also requires the example credential issuer and STS mock for end-to-end journey functionality.
 
 > **Note:** Authentication is disabled in `local` and `integration` environments. It is only active in `dev`, `build`, and `staging`.
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -51,24 +51,28 @@ Mappings:
       DocumentBuilderImageRepository: arn:aws:ecr:eu-west-2:219494607463:repository/doc-builder-image-repo-containerrepository-lc2jfleeqwvq
       OidcIssuerEndpoint: "https://auth-stub.mobile.dev.account.gov.uk"
       WalletApps: "govuk-build,wallet-test-dev,wallet-test-build"
+      OneLoginAuthServerUrl: "sts-mock.wallet-onboarding.dev.account.gov.uk"
     build:
       CredentialIssuerUrl: "example-credential-issuer.wallet-onboarding.build.account.gov.uk"
       SelfUrl: "stub-credential-issuer.wallet-onboarding.build.account.gov.uk"
       DocumentBuilderImageRepository: arn:aws:ecr:eu-west-2:899032468188:repository/doc-builder-image-repo-containerrepository-edrvcvwivlcg
       OidcIssuerEndpoint: "https://auth-stub.mobile.build.account.gov.uk"
       WalletApps: "govuk-build,wallet-test-dev,wallet-test-build"
+      OneLoginAuthServerUrl: "sts-mock.wallet-onboarding.build.account.gov.uk"
     staging:
       CredentialIssuerUrl: "example-credential-issuer.wallet-onboarding.staging.account.gov.uk"
       SelfUrl: "stub-credential-issuer.wallet-onboarding.staging.account.gov.uk"
       DocumentBuilderImageRepository: arn:aws:ecr:eu-west-2:899032468188:repository/doc-builder-image-repo-containerrepository-edrvcvwivlcg
       OidcIssuerEndpoint: "https://oidc.staging.account.gov.uk"
       WalletApps: "govuk-staging,wallet-test-staging"
+      OneLoginAuthServerUrl: "" # Not required as functionality to issue credential without the wallet isn't available
     integration:
       CredentialIssuerUrl: "example-credential-issuer.wallet-onboarding.integration.account.gov.uk"
       SelfUrl: "stub-credential-issuer.wallet-onboarding.integration.account.gov.uk"
       DocumentBuilderImageRepository: arn:aws:ecr:eu-west-2:899032468188:repository/doc-builder-image-repo-containerrepository-edrvcvwivlcg
       OidcIssuerEndpoint: "" # Not required as the DVS flow doesn't require authentication
       WalletApps: "wallet-test-verifier-integration"
+      OneLoginAuthServerUrl: "" # Not required as functionality to issue credential without the wallet isn't available
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416
@@ -413,6 +417,10 @@ Resources:
               Value: !FindInMap [EnvironmentVariables, !Ref Environment, OidcIssuerEndpoint]
             - Name: WALLET_APPS
               Value: !FindInMap [EnvironmentVariables, !Ref Environment, WalletApps]
+            - Name: ONE_LOGIN_AUTH_SERVER_URL
+              Value: !Sub
+                - "https://${OneLoginAuthServerUrl}"
+                - OneLoginAuthServerUrl: !FindInMap [ EnvironmentVariables, !Ref Environment, OneLoginAuthServerUrl ]
           PortMappings:
             - ContainerPort: !Ref ContainerPort
               Protocol: tcp

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -65,14 +65,14 @@ Mappings:
       DocumentBuilderImageRepository: arn:aws:ecr:eu-west-2:899032468188:repository/doc-builder-image-repo-containerrepository-edrvcvwivlcg
       OidcIssuerEndpoint: "https://oidc.staging.account.gov.uk"
       WalletApps: "govuk-staging,wallet-test-staging"
-      OneLoginAuthServerUrl: "" # Not required as functionality to issue credential without the wallet isn't available
+      OneLoginAuthServerUrl: "" # Not required as functionality to issue credential without the wallet isn't available in staging
     integration:
       CredentialIssuerUrl: "example-credential-issuer.wallet-onboarding.integration.account.gov.uk"
       SelfUrl: "stub-credential-issuer.wallet-onboarding.integration.account.gov.uk"
       DocumentBuilderImageRepository: arn:aws:ecr:eu-west-2:899032468188:repository/doc-builder-image-repo-containerrepository-edrvcvwivlcg
       OidcIssuerEndpoint: "" # Not required as the DVS flow doesn't require authentication
       WalletApps: "wallet-test-verifier-integration"
-      OneLoginAuthServerUrl: "" # Not required as functionality to issue credential without the wallet isn't available
+      OneLoginAuthServerUrl: "" # Not required as functionality to issue credential without the wallet isn't available in integration
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416

--- a/package-lock.json
+++ b/package-lock.json
@@ -7811,6 +7811,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -77,3 +77,7 @@ export function getWalletApps(): string[] {
 export function getTableItemTtl(): number {
   return 43200;
 }
+
+export function getOneLoginAuthServerUrl(): string {
+  return getEnvVarValue("ONE_LOGIN_AUTH_SERVER_URL");
+}

--- a/src/credentialViewer/services/credentialService.ts
+++ b/src/credentialViewer/services/credentialService.ts
@@ -1,5 +1,9 @@
 import axios from "axios";
-import { getCriEndpoint, getSelfUrl } from "../../config/appConfig";
+import {
+  getCriEndpoint,
+  getOneLoginAuthServerUrl,
+  getSelfUrl,
+} from "../../config/appConfig";
 import { GrantType } from "../../stsStubAccessToken/token/validateTokenRequest";
 
 /**
@@ -11,7 +15,7 @@ export async function getAccessToken(
   preAuthorizedCode: string,
 ): Promise<string> {
   const response = await axios.post(
-    `${getSelfUrl()}/token`,
+    `${getOneLoginAuthServerUrl()}/token`,
     {
       grant_type: GrantType.PREAUTHORIZED_CODE,
       "pre-authorized_code": preAuthorizedCode,

--- a/test/config/appConfig.test.ts
+++ b/test/config/appConfig.test.ts
@@ -12,6 +12,7 @@ import {
   getWalletApps,
   getTableItemTtl,
   getPhotosBucketName,
+  getOneLoginAuthServerUrl,
 } from "../../src/config/appConfig";
 
 describe("appConfig.ts", () => {
@@ -165,5 +166,17 @@ describe("appConfig.ts", () => {
 
   it("should return table item TTL", () => {
     expect(getTableItemTtl()).toEqual(43200);
+  });
+
+  it("should throw an error if ONE_LOGIN_AUTH_SERVER_URL environment variable is not set", () => {
+    delete process.env.ONE_LOGIN_AUTH_SERVER_URL;
+    expect(() => getOneLoginAuthServerUrl()).toThrow(
+      new Error("ONE_LOGIN_AUTH_SERVER_URL environment variable not set"),
+    );
+  });
+
+  it("should return ONE_LOGIN_AUTH_SERVER_URL environment variable value if set", () => {
+    process.env.ONE_LOGIN_AUTH_SERVER_URL = "test-ol-auth-server-url";
+    expect(getOneLoginAuthServerUrl()).toEqual("test-ol-auth-server-url");
   });
 });

--- a/test/credentialViewer/controller.test.ts
+++ b/test/credentialViewer/controller.test.ts
@@ -2,6 +2,8 @@ import { MDOC_TEST_DATA, VCDM_TEST_DATA } from "./testData";
 
 process.env.SELF = "https://doc-builder.test";
 process.env.CREDENTIAL_ISSUER_URL = "https://example-cri.test";
+process.env.ONE_LOGIN_AUTH_SERVER_URL = "https://sts-mock.test";
+
 import { credentialViewerController } from "../../src/credentialViewer/controller";
 import { getMockReq, getMockRes } from "@jest-mock/express";
 import axios, { AxiosResponse } from "axios";
@@ -57,7 +59,7 @@ describe("controller.ts", () => {
 
     expect(mockedAxios.post).toHaveBeenNthCalledWith(
       1,
-      "https://doc-builder.test/token",
+      "https://sts-mock.test/token",
       {
         grant_type: "urn:ietf:params:oauth:grant-type:pre-authorized_code",
         "pre-authorized_code":
@@ -151,7 +153,7 @@ describe("controller.ts", () => {
 
     expect(mockedAxios.post).toHaveBeenNthCalledWith(
       1,
-      "https://doc-builder.test/token",
+      "https://sts-mock.test/token",
       {
         grant_type: "urn:ietf:params:oauth:grant-type:pre-authorized_code",
         "pre-authorized_code":

--- a/test/credentialViewer/services/credentialService.test.ts
+++ b/test/credentialViewer/services/credentialService.test.ts
@@ -1,5 +1,6 @@
 process.env.SELF = "https://doc-builder.test";
 process.env.CREDENTIAL_ISSUER_URL = "https://example-cri.test";
+process.env.ONE_LOGIN_AUTH_SERVER_URL = "https://sts-mock.test";
 
 import axios, { AxiosResponse } from "axios";
 import {
@@ -29,7 +30,7 @@ describe("credentialService", () => {
 
       expect(result).toBe(expectedAccessToken);
       expect(mockedAxios.post).toHaveBeenCalledWith(
-        "https://doc-builder.test/token",
+        "https://sts-mock.test/token",
         {
           grant_type: "urn:ietf:params:oauth:grant-type:pre-authorized_code",
           "pre-authorized_code": preAuthorizedCode,


### PR DESCRIPTION
## Proposed changes
### What changed
- Added a new environment variable `ONE_LOGIN_AUTH_SERVER_URL` to contain the STS mock URL for `dev`, `build` and `local` environments
- Updated the logic in the `credentialService` (part of the "View Credential" functionality) to fetch the access token for credential issuance from the STS mock instead of the Document Builder internal STS mock (to be deleted in [DCMAW-18837](https://govukverify.atlassian.net/browse/DCMAW-18837))
- Updated `package-lock.json` with `npm install` to fix issue with `package.json` and `package-lock.json ` being out of sync

### Why did it change
- To integrate with the new mock of STS

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-19107](https://govukverify.atlassian.net/browse/DCMAW-19107)

## Testing
**Tested in `dev`:**

New env var `ONE_LOGIN_AUTH_SERVER_URL` in ECS task definition
<img width="1257" height="527" alt="Screenshot 2026-04-14 at 15 46 58" src="https://github.com/user-attachments/assets/ac588917-cbe9-4404-b8ce-5cbd7778f6f9" />

Credential issued with an access token issued by the STS mock
<img width="1257" height="466" alt="Screenshot 2026-04-14 at 15 48 21" src="https://github.com/user-attachments/assets/1f9b7bbe-0a66-422d-847a-6d5d0d77dd4c" />

**Tested locally:**

Credential issued with an access token issued by the STS mock
<img width="1201" height="450" alt="Screenshot 2026-04-14 at 16 10 59" src="https://github.com/user-attachments/assets/e74c7b60-cfd8-49eb-9279-163ff1ebd753" />

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-19107]: https://govukverify.atlassian.net/browse/DCMAW-19107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCMAW-18837]: https://govukverify.atlassian.net/browse/DCMAW-18837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ