### PR TITLE
build: integrate current alarms with Slack - DCMAW 18238

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -707,7 +707,7 @@ Resources:
 
   # ALARMS
   DocBuilderLowContainerTaskCountAlarm:
-    Condition: IsBuildOrStagingOrInt
+#    Condition: IsBuildOrStagingOrInt
     DependsOn:
       - WalletFECluster
       - WalletFEECSService
@@ -743,7 +743,7 @@ Resources:
             Stat: Minimum
 
   FE5XXErrorAlarm:
-    Condition: IsBuildOrStagingOrInt
+#    Condition: IsBuildOrStagingOrInt
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -717,9 +717,9 @@ Resources:
       AlarmDescription: Trigger the alarm if the running container task count drops below 1
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue alarm-sns-topic-critical
+        - !ImportValue alarm-sns-topic-warning
       OKActions:
-        - !ImportValue alarm-sns-topic-critical
+        - !ImportValue alarm-sns-topic-warning
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 1
@@ -750,9 +750,9 @@ Resources:
       AlarmDescription: Trigger the alarm if errorThreshold exceeds 50% with a minimum of 5 invocations in the last 30 minutes
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue alarm-sns-topic-critical
+        - !ImportValue alarm-sns-topic-warning
       OKActions:
-        - !ImportValue alarm-sns-topic-critical
+        - !ImportValue alarm-sns-topic-warning
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 1

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -706,7 +706,11 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DocBuilderLowContainerTaskCountAlarm"
       AlarmDescription: Trigger a warning if the running container task count drops below 1
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-sns-topic-critical
+      OKActions:
+        - !ImportValue alarm-sns-topic-critical
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 1

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -707,7 +707,7 @@ Resources:
 
   # ALARMS
   DocBuilderLowContainerTaskCountAlarm:
-#    Condition: IsBuildOrStagingOrInt
+    Condition: IsBuildOrStagingOrInt
     DependsOn:
       - WalletFECluster
       - WalletFEECSService
@@ -743,7 +743,7 @@ Resources:
             Stat: Minimum
 
   FE5XXErrorAlarm:
-#    Condition: IsBuildOrStagingOrInt
+    Condition: IsBuildOrStagingOrInt
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -699,6 +699,7 @@ Resources:
 
   # ALARMS
   DocBuilderLowContainerTaskCountAlarm:
+    Condition: IsBuildOrStagingOrInt
     DependsOn:
       - WalletFECluster
       - WalletFEECSService
@@ -734,6 +735,7 @@ Resources:
             Stat: Minimum
 
   BE5XXErrorAlarm:
+    Condition: IsBuildOrStagingOrInt
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-BE5XXErrorAlarm"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -699,7 +699,6 @@ Resources:
 
   # ALARMS
   DocBuilderLowContainerTaskCountAlarm:
-    Condition: IsBuildOrStagingOrInt
     DependsOn:
       - WalletFECluster
       - WalletFEECSService
@@ -731,7 +730,6 @@ Resources:
             Stat: Minimum
 
   BE5XXErrorAlarm:
-    Condition: IsBuildOrStagingOrInt
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-BE5XXErrorAlarm"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -706,7 +706,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DocBuilderLowContainerTaskCountAlarm"
-      AlarmDescription: Trigger a warning if the running container task count drops below 1
+      AlarmDescription: Trigger the alarm if the running container task count drops below 1
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-sns-topic-critical
@@ -734,11 +734,11 @@ Resources:
             Period: 60
             Stat: Minimum
 
-  BE5XXErrorAlarm:
+  FE5XXErrorAlarm:
     Condition: IsBuildOrStagingOrInt
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-BE5XXErrorAlarm"
+      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"
       AlarmDescription: Trigger the alarm if errorThreshold exceeds 50% with a minimum of 5 invocations in the last 30 minutes
       ActionsEnabled: true
       AlarmActions:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -738,7 +738,11 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-BE5XXErrorAlarm"
       AlarmDescription: Trigger the alarm if errorThreshold exceeds 50% with a minimum of 5 invocations in the last 30 minutes
-      ActionsEnabled: false
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-sns-topic-critical
+      OKActions:
+        - !ImportValue alarm-sns-topic-critical
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 1


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

Our current doc builder alarms (low task-count, 5xx API errors) have been integrated to Slack as warning alerts.

We are alerted on both 'alarm actions' and 'ok actions'.

### Why did it change
<!-- Describe the reason these changes were made -->

<img width="768" height="791" alt="image" src="https://github.com/user-attachments/assets/c7911310-8dd9-4173-ab56-2e0eada58927" />


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-18238](https://govukverify.atlassian.net/browse/DCMAW-18238)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-18238]: https://govukverify.atlassian.net/browse/DCMAW-18238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ