### PR TITLE
chore: changed the alarm-conditional to exclude build - DCMAW-18238

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -32,8 +32,7 @@ Parameters:
 Conditions:
   StackNameIsWalletDocBuilderFE: !Equals [!Ref "AWS::StackName", wallet-doc-builder]
 
-  IsBuildOrStagingOrInt: !Or
-    - !Equals [!Ref Environment, build]
+  IsStagingOrInt: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
 
@@ -707,7 +706,7 @@ Resources:
 
   # ALARMS
   DocBuilderLowContainerTaskCountAlarm:
-    Condition: IsBuildOrStagingOrInt
+    Condition: IsStagingOrInt
     DependsOn:
       - WalletFECluster
       - WalletFEECSService
@@ -743,7 +742,7 @@ Resources:
             Stat: Minimum
 
   FE5XXErrorAlarm:
-    Condition: IsBuildOrStagingOrInt
+    Condition: IsStagingOrInt
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

Alarm-deploy-conditional changed to exclude the build environment

### Why did it change
<!-- Describe the reason these changes were made -->

Alarms have been specified to only deploy to staging and int (and dev for testing) - none of the alarming infrastructure is available in build, and deployment of the alarms has blocked the pipeline

<img width="897" height="432" alt="image" src="https://github.com/user-attachments/assets/02f7de4e-9aaf-462f-8a10-5a7daa1d9378" />


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-18238](https://govukverify.atlassian.net/browse/DCMAW-18238)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-18238]: https://govukverify.atlassian.net/browse/DCMAW-18238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ